### PR TITLE
Caption download and other CLI refactors/tests

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,7 @@
 version = 1
 
 test_patterns = [
-  "*/tests/**"
+  "tests/**"
 ]
 
 exclude_patterns = [

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ pytube also ships with a tiny cli interface for downloading and probing videos.
 Let's start with downloading:
 
 ```bash
-$ pytube3 http://youtube.com/watch?v=9bZkp7q19f0 --itag=22
+$ pytube3 http://youtube.com/watch?v=9bZkp7q19f0 --itag=18
 ```
 To view available streams:
 

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -127,11 +127,11 @@ class Caption:
 
         file_path = os.path.join(output_path, filename)
 
-        with open(file_path, "w", encoding="utf-8") as fh:
+        with open(file_path, "w", encoding="utf-8") as file_handle:
             if srt:
-                fh.write(self.generate_srt_captions())
+                file_handle.write(self.generate_srt_captions())
             else:
-                fh.write(self.xml_captions())
+                file_handle.write(self.xml_captions)
 
         return file_path
 

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -114,12 +114,12 @@ class Caption:
         else:
             filename = title
 
-        filename = safe_filename(filename)
-
         if filename_prefix:
             filename = "{prefix}{filename}".format(
                 prefix=safe_filename(filename_prefix), filename=filename,
             )
+
+        filename = safe_filename(filename)
 
         filename += " ({})".format(self.code)
 

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 import math
+import os
 import time
 import xml.etree.ElementTree as ElementTree
-from typing import Dict
+from typing import Dict, Optional
 
 from pytube import request
 from html import unescape
+
+from pytube.helpers import safe_filename
 
 
 class Caption:
@@ -72,6 +75,65 @@ class Caption:
             )
             segments.append(line)
         return "\n".join(segments).strip()
+
+    def download(
+        self,
+        title: str,
+        srt: bool = True,
+        output_path: Optional[str] = None,
+        filename_prefix: Optional[str] = None,
+    ) -> str:
+        """Write the media stream to disk.
+
+        :param filename:
+            Output filename (stem only) for writing media file.
+            If one is not specified, the default filename is used.
+        :type filename: str
+        :param srt:
+            Set to True to download srt, false to download xml. Defaults to True.
+        :type srt bool
+        :param output_path:
+            (optional) Output path for writing media file. If one is not
+            specified, defaults to the current working directory.
+        :type output_path: str or None
+        :param filename_prefix:
+            (optional) A string that will be prepended to the filename.
+            For example a number in a playlist or the name of a series.
+            If one is not specified, nothing will be prepended
+            This is separate from filename so you can use the default
+            filename but still add a prefix.
+        :type filename_prefix: str or None
+
+        :rtype: str
+
+        """
+        output_path = output_path or os.getcwd()
+        filename = safe_filename(title)
+
+        if filename_prefix:
+            filename = "{prefix}{filename}".format(
+                prefix=safe_filename(filename_prefix), filename=filename,
+            )
+
+        if filename.endswith(".srt") or filename.endswith(".xml"):
+            filename = ".".join(filename.split(".")[:-1])
+
+        filename += " ({})".format(self.code)
+
+        if srt:
+            filename += ".srt"
+        else:
+            filename += ".xml"
+
+        file_path = os.path.join(output_path, filename)
+
+        with open(file_path, "w", encoding="utf-8") as fh:
+            if srt:
+                fh.write(self.generate_srt_captions())
+            else:
+                fh.write(self.xml_captions())
+
+        return file_path
 
     def __repr__(self):
         """Printable object representation."""

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -108,15 +108,18 @@ class Caption:
 
         """
         output_path = output_path or os.getcwd()
-        filename = safe_filename(title)
+
+        if title.endswith(".srt") or title.endswith(".xml"):
+            filename = ".".join(title.split(".")[:-1])
+        else:
+            filename = title
+
+        filename = safe_filename(filename)
 
         if filename_prefix:
             filename = "{prefix}{filename}".format(
                 prefix=safe_filename(filename_prefix), filename=filename,
             )
-
-        if filename.endswith(".srt") or filename.endswith(".xml"):
-            filename = ".".join(filename.split(".")[:-1])
 
         filename += " ({})".format(self.code)
 

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 from io import BufferedWriter
-from typing import Tuple, Any, Optional
+from typing import Tuple, Any, Optional, List
 
 from pytube import __version__, CaptionQuery
 from pytube import YouTube
@@ -22,6 +22,28 @@ def main():
     """Command line application to download youtube videos."""
     # noinspection PyTypeChecker
     parser = argparse.ArgumentParser(description=main.__doc__)
+    args = _parse_args(parser)
+    logging.getLogger().setLevel(max(3 - args.verbosity, 0) * 10)
+
+    if not args.url:
+        parser.print_help()
+        sys.exit(1)
+
+    youtube = YouTube(args.url)
+
+    if args.list:
+        display_streams(youtube)
+    if args.build_playback_report:
+        build_playback_report(youtube)
+    if args.itag:
+        download(youtube=youtube, itag=args.itag)
+    if hasattr(args, "caption_code"):
+        download_caption(youtube=youtube, lang_code=args.caption_code)
+
+
+def _parse_args(
+    parser: argparse.ArgumentParser, args: Optional[List] = None
+) -> argparse.Namespace:
     parser.add_argument("url", help="The YouTube /watch url", nargs="?")
     parser.add_argument(
         "--version", action="version", version="%(prog)s " + __version__,
@@ -63,23 +85,7 @@ def main():
         ),
     )
 
-    args = parser.parse_args()
-    logging.getLogger().setLevel(max(3 - args.verbosity, 0) * 10)
-
-    if not args.url:
-        parser.print_help()
-        sys.exit(1)
-
-    youtube = YouTube(args.url)
-
-    if args.list:
-        display_streams(youtube)
-    if args.build_playback_report:
-        build_playback_report(youtube)
-    if args.itag:
-        download(youtube=youtube, itag=args.itag)
-    if hasattr(args, "caption_code"):
-        download_caption(youtube=youtube, lang_code=args.caption_code)
+    return parser.parse_args(args)
 
 
 def build_playback_report(youtube: YouTube) -> None:

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -159,7 +159,7 @@ def on_progress(
     display_progress_bar(bytes_received, filesize)
 
 
-def download(youtube: YouTube, itag: str) -> None:
+def download(youtube: YouTube, itag: int) -> None:
     """Start downloading a YouTube video.
 
     :param YouTube youtube:
@@ -170,13 +170,14 @@ def download(youtube: YouTube, itag: str) -> None:
     """
     # TODO(nficano): allow download target to be specified
     # TODO(nficano): allow dash itags to be selected
-    youtube.register_on_progress_callback(on_progress)
-    stream = youtube.streams.get_by_itag(int(itag))
+    stream = youtube.streams.get_by_itag(itag)
     if stream is None:
         print("Could not find a stream with itag: {itag}".format(itag=itag))
         print("Try one of these:")
         display_streams(youtube)
         sys.exit()
+
+    youtube.register_on_progress_callback(on_progress)
     print("\n{fn} | {fs} bytes".format(fn=stream.default_filename, fs=stream.filesize,))
     try:
         stream.download()

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -1,3 +1,6 @@
+from unittest import mock
+from unittest.mock import patch, mock_open
+
 from pytube import Caption, CaptionQuery
 
 
@@ -39,3 +42,27 @@ def test_caption_query_get_by_language_code_when_not_exists():
     )
     caption_query = CaptionQuery(captions=[caption1, caption2])
     assert caption_query.get_by_language_code("hello") is None
+
+
+@mock.patch("pytube.captions.Caption.generate_srt_captions")
+def test_download(srt):
+    m = mock_open()
+    with patch("builtins.open", m):
+        srt.return_value = ""
+        caption = Caption(
+            {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+        )
+        caption.download("title")
+        assert m.call_args_list[0][0][0].split("/")[-1] == "title (en).srt"
+
+
+@mock.patch("pytube.captions.Caption.xml_captions")
+def test_download_xml_and_trim_extension(xml):
+    m = mock_open()
+    with patch("builtins.open", m):
+        xml.return_value = ""
+        caption = Caption(
+            {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+        )
+        caption.download("title.xml", srt=False)
+        assert m.call_args_list[0][0][0].split("/")[-1] == "title (en).xml"

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -46,38 +46,38 @@ def test_caption_query_get_by_language_code_when_not_exists():
 
 @mock.patch("pytube.captions.Caption.generate_srt_captions")
 def test_download(srt):
-    m = mock_open()
+    open_mock = mock_open()
     with patch("builtins.open", m):
         srt.return_value = ""
         caption = Caption(
             {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
         )
         caption.download("title")
-        assert m.call_args_list[0][0][0].split("/")[-1] == "title (en).srt"
+        assert open_mock.call_args_list[0][0][0].split("/")[-1] == "title (en).srt"
 
 
 @mock.patch("pytube.captions.Caption.generate_srt_captions")
 def test_download_with_prefix(srt):
-    m = mock_open()
+    open_mock = mock_open()
     with patch("builtins.open", m):
         srt.return_value = ""
         caption = Caption(
             {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
         )
         caption.download("title", filename_prefix="1 ")
-        assert m.call_args_list[0][0][0].split("/")[-1] == "1 title (en).srt"
+        assert open_mock.call_args_list[0][0][0].split("/")[-1] == "1 title (en).srt"
 
 
 @mock.patch("pytube.captions.Caption.xml_captions")
 def test_download_xml_and_trim_extension(xml):
-    m = mock_open()
+    open_mock = mock_open()
     with patch("builtins.open", m):
         xml.return_value = ""
         caption = Caption(
             {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
         )
         caption.download("title.xml", srt=False)
-        assert m.call_args_list[0][0][0].split("/")[-1] == "title (en).xml"
+        assert open_mock.call_args_list[0][0][0].split("/")[-1] == "title (en).xml"
 
 
 def test_repr():

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -47,7 +47,7 @@ def test_caption_query_get_by_language_code_when_not_exists():
 @mock.patch("pytube.captions.Caption.generate_srt_captions")
 def test_download(srt):
     open_mock = mock_open()
-    with patch("builtins.open", m):
+    with patch("builtins.open", open_mock):
         srt.return_value = ""
         caption = Caption(
             {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
@@ -59,7 +59,7 @@ def test_download(srt):
 @mock.patch("pytube.captions.Caption.generate_srt_captions")
 def test_download_with_prefix(srt):
     open_mock = mock_open()
-    with patch("builtins.open", m):
+    with patch("builtins.open", open_mock):
         srt.return_value = ""
         caption = Caption(
             {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
@@ -71,7 +71,7 @@ def test_download_with_prefix(srt):
 @mock.patch("pytube.captions.Caption.xml_captions")
 def test_download_xml_and_trim_extension(xml):
     open_mock = mock_open()
-    with patch("builtins.open", m):
+    with patch("builtins.open", open_mock):
         xml.return_value = ""
         caption = Caption(
             {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -56,6 +56,18 @@ def test_download(srt):
         assert m.call_args_list[0][0][0].split("/")[-1] == "title (en).srt"
 
 
+@mock.patch("pytube.captions.Caption.generate_srt_captions")
+def test_download_with_prefix(srt):
+    m = mock_open()
+    with patch("builtins.open", m):
+        srt.return_value = ""
+        caption = Caption(
+            {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+        )
+        caption.download("title", filename_prefix="1 ")
+        assert m.call_args_list[0][0][0].split("/")[-1] == "1 title (en).srt"
+
+
 @mock.patch("pytube.captions.Caption.xml_captions")
 def test_download_xml_and_trim_extension(xml):
     m = mock_open()
@@ -66,3 +78,10 @@ def test_download_xml_and_trim_extension(xml):
         )
         caption.download("title.xml", srt=False)
         assert m.call_args_list[0][0][0].split("/")[-1] == "title (en).xml"
+
+
+def test_repr():
+    caption = Caption(
+        {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+    )
+    assert str(caption) == '<Caption lang="name1" code="en">'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,3 +79,12 @@ def test_download_caption_with_language_not_found(youtube):
     ) as wrapped_all:
         cli.download_caption(youtube, "blah")
         wrapped_all.assert_called()
+
+
+@mock.patch("pytube.Stream")
+@mock.patch("io.BufferedWriter")
+def test_on_progress(stream, writer):
+    stream.filesize = 10
+    cli.display_progress_bar = MagicMock()
+    cli.on_progress(stream, "", writer, 7)
+    cli.display_progress_bar.assert_called_once_with(3, 10)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,8 @@ from pytube import cli
 
 
 @mock.patch("pytube.cli.YouTube")
-@mock.patch("pytube.cli.sys")
-def test_download(MockYouTube, mock_sys):
-    instance = MockYouTube.return_value
+def test_download(youtube):
+    instance = youtube.return_value
     instance.prefetch_descramble.return_value = None
     instance.streams = mock.Mock()
-    cli.download("asdf", 123)
+    cli.download(instance, 123)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,81 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
-from pytube import cli
+import pytest
+
+from pytube import cli, StreamQuery, Caption, CaptionQuery
 
 
 @mock.patch("pytube.cli.YouTube")
-def test_download(youtube):
-    instance = youtube.return_value
-    instance.prefetch_descramble.return_value = None
-    instance.streams = mock.Mock()
-    cli.download(instance, 123)
+def test_download_when_itag_not_found(youtube):
+    youtube.streams = mock.Mock()
+    youtube.streams.all.return_value = []
+    youtube.streams.get_by_itag.return_value = None
+    with pytest.raises(SystemExit):
+        cli.download(youtube, 123)
+    youtube.streams.get_by_itag.assert_called_with(123)
+
+
+@mock.patch("pytube.cli.YouTube")
+@mock.patch("pytube.Stream")
+def test_download_when_itag_is_found(youtube, stream):
+    stream.itag = 123
+    youtube.streams = StreamQuery([stream])
+    with patch.object(
+        youtube.streams, "get_by_itag", wraps=youtube.streams.get_by_itag
+    ) as wrapped_itag:
+        cli.download(youtube, 123)
+        wrapped_itag.assert_called_with(123)
+    youtube.register_on_progress_callback.assert_called_with(cli.on_progress)
+    stream.download.assert_called()
+
+
+@mock.patch("pytube.cli.YouTube")
+@mock.patch("pytube.Stream")
+def test_display_stream(youtube, stream):
+    stream.itag = 123
+    stream.__repr__ = MagicMock(return_value="")
+    youtube.streams = StreamQuery([stream])
+    with patch.object(youtube.streams, "all", wraps=youtube.streams.all) as wrapped_all:
+        cli.display_streams(youtube)
+        wrapped_all.assert_called()
+        stream.__repr__.assert_called()
+
+
+@mock.patch("pytube.cli.YouTube")
+def test_download_caption_with_none(youtube):
+    caption = Caption(
+        {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+    )
+    youtube.captions = CaptionQuery([caption])
+    with patch.object(
+        youtube.captions, "all", wraps=youtube.captions.all
+    ) as wrapped_all:
+        cli.download_caption(youtube, None)
+        wrapped_all.assert_called()
+
+
+@mock.patch("pytube.cli.YouTube")
+def test_download_caption_with_language_found(youtube):
+    youtube.title = "video title"
+    caption = Caption(
+        {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+    )
+    caption.download = MagicMock(return_value="file_path")
+    youtube.captions = CaptionQuery([caption])
+    cli.download_caption(youtube, "en")
+    caption.download.assert_called_with(title="video title")
+
+
+@mock.patch("pytube.cli.YouTube")
+def test_download_caption_with_language_not_found(youtube):
+    caption = Caption(
+        {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+    )
+    youtube.captions = CaptionQuery([caption])
+    with patch.object(
+        youtube.captions, "all", wraps=youtube.captions.all
+    ) as wrapped_all:
+        cli.download_caption(youtube, "blah")
+        wrapped_all.assert_called()


### PR DESCRIPTION
* only download once regardless of flags
* Add `-c` flag to download caption file
* Display list of available `itag`s if specified one not found