### PR TITLE
Audio only option

### DIFF
--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 from io import BufferedWriter
-from typing import Tuple, Any, Optional, List, Union
+from typing import Tuple, Any, Optional, List
 
 from pytube import __version__, CaptionQuery, Stream
 from pytube import YouTube
@@ -42,7 +42,7 @@ def main():
     if args.resolution:
         download_by_resolution(youtube=youtube, resolution=args.resolution)
     if args.audio:
-        download_audio(youtube=youtube, format=args.audio)
+        download_audio(youtube=youtube, filetype=args.audio)
 
 
 def _parse_args(
@@ -237,14 +237,14 @@ def download_by_resolution(youtube: YouTube, resolution: str) -> None:
         sys.exit()
 
     youtube.register_on_progress_callback(on_progress)
-
+swiftyy-mage:master
     try:
         _download(stream)
     except KeyboardInterrupt:
         sys.exit()
 
 
-def download_audio(youtube: YouTube, format: str) -> None:
+def download_audio(youtube: YouTube, filetype: str) -> None:
     """
     Start downloading a YouTube video.
     
@@ -252,9 +252,9 @@ def download_audio(youtube: YouTube, format: str) -> None:
         A valid YouTube object.
     :param str format:
         Desired file format to download.
-        
+
     """
-    audio = youtube.streams.filter(only_audio=True, subtype=format)\
+    audio = youtube.streams.filter(only_audio=True, subtype=filetype)\
         .order_by("abr").desc().first()
 
     if audio is None:

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -237,7 +237,7 @@ def download_by_resolution(youtube: YouTube, resolution: str) -> None:
         sys.exit()
 
     youtube.register_on_progress_callback(on_progress)
-swiftyy-mage:master
+
     try:
         _download(stream)
     except KeyboardInterrupt:
@@ -250,7 +250,7 @@ def download_audio(youtube: YouTube, filetype: str) -> None:
     
     :param YouTube youtube:
         A valid YouTube object.
-    :param str format:
+    :param str filetype:
         Desired file format to download.
 
     """

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -242,7 +242,15 @@ def download_by_resolution(youtube: YouTube, resolution: str) -> None:
     except KeyboardInterrupt:
         sys.exit()
 
+        
 def download_audio(youtube: YouTube) -> None:
+    """
+    Start downloading a YouTube video.
+    
+    :param YouTube youtube:
+        A valid YouTube object.
+        
+    """
     audio = youtube.streams.filter(only_audio=True).order_by("abr").desc().first()
     if audio is None:
         print(
@@ -256,6 +264,7 @@ def download_audio(youtube: YouTube) -> None:
         _download(audio)
     except KeyboardInterrupt:
         sys.exit()
+        
 
 def display_streams(youtube: YouTube) -> None:
     """Probe YouTube video and lists its available formats.

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 from io import BufferedWriter
-from typing import Tuple, Any, Optional, List
+from typing import Tuple, Any, Optional, List, Union
 
 from pytube import __version__, CaptionQuery, Stream
 from pytube import YouTube
@@ -42,7 +42,7 @@ def main():
     if args.resolution:
         download_by_resolution(youtube=youtube, resolution=args.resolution)
     if args.audio:
-        download_audio(youtube=youtube)
+        download_audio(youtube=youtube, format=args.audio)
 
 
 def _parse_args(
@@ -94,7 +94,8 @@ def _parse_args(
     parser.add_argument(
         "-a",
         "--audio",
-        action="store_true",
+        const="mp4",
+        nargs="?",
         help=(
             "Download the audio for a given URL at the highest bitrate available"
         )
@@ -242,16 +243,20 @@ def download_by_resolution(youtube: YouTube, resolution: str) -> None:
     except KeyboardInterrupt:
         sys.exit()
 
-        
-def download_audio(youtube: YouTube) -> None:
+
+def download_audio(youtube: YouTube, format: str) -> None:
     """
     Start downloading a YouTube video.
     
     :param YouTube youtube:
         A valid YouTube object.
+    :param str format:
+        Desired file format to download.
         
     """
-    audio = youtube.streams.filter(only_audio=True).order_by("abr").desc().first()
+    audio = youtube.streams.filter(only_audio=True, subtype=format)\
+        .order_by("abr").desc().first()
+
     if audio is None:
         print(
             "No audio only stream found. Try one of these:")
@@ -264,7 +269,7 @@ def download_audio(youtube: YouTube) -> None:
         _download(audio)
     except KeyboardInterrupt:
         sys.exit()
-        
+
 
 def display_streams(youtube: YouTube) -> None:
     """Probe YouTube video and lists its available formats.


### PR DESCRIPTION
Added an argument for the CLI which ensures that the audio only stream with the highest average bitrate is downloaded. Other arguments can be used this, but will not affect the result of this one.
I've never seen a youtube video without an audio only stream, but I can't be sure. I just decided on defaulting to the highest abr which is usually a webm. I don't really know much about audio encoding so if anyone has a better way to sort the audio streams, I'm open to suggestions.