### PR TITLE
Playlist download improvements and target directory download

### DIFF
--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 from pytube import request
 from html import unescape
 
-from pytube.helpers import safe_filename
+from pytube.helpers import safe_filename, target_directory
 
 
 class Caption:
@@ -107,8 +107,6 @@ class Caption:
         :rtype: str
 
         """
-        output_path = output_path or os.getcwd()
-
         if title.endswith(".srt") or title.endswith(".xml"):
             filename = ".".join(title.split(".")[:-1])
         else:
@@ -128,7 +126,7 @@ class Caption:
         else:
             filename += ".xml"
 
-        file_path = os.path.join(output_path, filename)
+        file_path = os.path.join(target_directory(output_path), filename)
 
         with open(file_path, "w", encoding="utf-8") as file_handle:
             if srt:

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -144,7 +144,7 @@ def get_transform_map(js: str, var: str) -> Dict:
     return mapper
 
 
-def reverse(arr: List, b: Optional[Any]):
+def reverse(arr: List, _: Optional[Any]):
     """Reverse elements in a list.
 
     This function is equivalent to:

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -16,7 +16,7 @@ signature and decoding it.
 
 import re
 from itertools import chain
-from typing import List, Tuple, Dict, Callable
+from typing import List, Tuple, Dict, Callable, Any, Optional
 
 from pytube.exceptions import RegexMatchError
 from pytube.helpers import regex_search, create_logger
@@ -144,7 +144,7 @@ def get_transform_map(js: str, var: str) -> Dict:
     return mapper
 
 
-def reverse(arr, b):
+def reverse(arr:List, b:Optional[Any]):
     """Reverse elements in a list.
 
     This function is equivalent to:
@@ -164,7 +164,7 @@ def reverse(arr, b):
     return arr[::-1]
 
 
-def splice(arr, b):
+def splice(arr:List, b:int):
     """Add/remove items to/from a list.
 
     This function is equivalent to:
@@ -181,7 +181,7 @@ def splice(arr, b):
     return arr[:b] + arr[b * 2 :]
 
 
-def swap(arr, b):
+def swap(arr:List, b:int):
     """Swap positions at b modulus the list length.
 
     This function is equivalent to:

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -144,7 +144,7 @@ def get_transform_map(js: str, var: str) -> Dict:
     return mapper
 
 
-def reverse(arr:List, b:Optional[Any]):
+def reverse(arr: List, b: Optional[Any]):
     """Reverse elements in a list.
 
     This function is equivalent to:
@@ -164,7 +164,7 @@ def reverse(arr:List, b:Optional[Any]):
     return arr[::-1]
 
 
-def splice(arr:List, b:int):
+def splice(arr: List, b: int):
     """Add/remove items to/from a list.
 
     This function is equivalent to:
@@ -181,7 +181,7 @@ def splice(arr:List, b:int):
     return arr[:b] + arr[b * 2 :]
 
 
-def swap(arr:List, b:int):
+def swap(arr: List, b: int):
     """Swap positions at b modulus the list length.
 
     This function is equivalent to:

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -31,6 +31,7 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    print("Loading video")
     if "/playlist" in args.url:
         playlist = Playlist(args.url)
         if not args.target:
@@ -67,7 +68,7 @@ def _perform_args_on_youtube(youtube: YouTube, args: argparse.Namespace) -> None
 def _parse_args(
     parser: argparse.ArgumentParser, args: Optional[List] = None
 ) -> argparse.Namespace:
-    parser.add_argument("url", help="The YouTube /watch url", nargs="?")
+    parser.add_argument("url", help="The YouTube /watch or /playlist url", nargs="?")
     parser.add_argument(
         "--version", action="version", version="%(prog)s " + __version__,
     )
@@ -195,7 +196,7 @@ def on_progress(
 
 
 def _download(stream: Stream, target: Optional[str] = None) -> None:
-    print("\n{fn} | {fs} bytes".format(fn=stream.default_filename, fs=stream.filesize))
+    print("{fn} | {fs} bytes".format(fn=stream.default_filename, fs=stream.filesize))
     stream.download(output_path=target)
     sys.stdout.write("\n")
 
@@ -210,7 +211,6 @@ def download_by_itag(youtube: YouTube, itag: int, target: Optional[str] = None) 
     :param str target:
         Target directory for download
     """
-    # TODO(nficano): allow dash itags to be selected
     stream = youtube.streams.get_by_itag(itag)
     if stream is None:
         print("Could not find a stream with itag: {itag}".format(itag=itag))

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -13,7 +13,7 @@ from typing import Tuple, Any, Optional, List
 
 from pytube import __version__, CaptionQuery, Stream, Playlist
 from pytube import YouTube
-
+from pytube.exceptions import PytubeError
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,11 @@ def main():
     if "/playlist" in args.url:
         playlist = Playlist(args.url)
         for youtube_video in playlist.videos:
-            _perform_args_on_youtube(youtube_video, args)
+            try:
+                _perform_args_on_youtube(youtube_video, args)
+            except PytubeError as e:
+                print(f"There was an error with video: {youtube_video}")
+                print(e)
     else:
         youtube = YouTube(args.url)
         _perform_args_on_youtube(youtube, args)

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -31,8 +31,8 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    print("Loading video")
     if "/playlist" in args.url:
+        print("Loading playlist...")
         playlist = Playlist(args.url)
         if not args.target:
             args.target = safe_filename(playlist.title())
@@ -43,6 +43,7 @@ def main():
                 print(f"There was an error with video: {youtube_video}")
                 print(e)
     else:
+        print("Loading video...")
         youtube = YouTube(args.url)
         _perform_args_on_youtube(youtube, args)
 
@@ -196,7 +197,8 @@ def on_progress(
 
 
 def _download(stream: Stream, target: Optional[str] = None) -> None:
-    print("{fn} | {fs} bytes".format(fn=stream.default_filename, fs=stream.filesize))
+    filesize_megabytes = stream.filesize // 1048576
+    print("{fn} | {fs} bytes".format(fn=stream.default_filename, fs=filesize_megabytes))
     stream.download(output_path=target)
     sys.stdout.write("\n")
 

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -63,7 +63,6 @@ def _perform_args_on_youtube(youtube: YouTube, args: argparse.Namespace) -> None
         download_by_resolution(
             youtube=youtube, resolution=args.resolution, target=args.target
         )
-    # TODO: default to download_highest_resultion if no actions specified
 
 
 def _parse_args(
@@ -299,7 +298,7 @@ def download_caption(
 
     caption = youtube.captions.get_by_language_code(lang_code=lang_code)
     if caption:
-        downloaded_path = caption.download(title=youtube.title)
+        downloaded_path = caption.download(title=youtube.title, output_path=target)
         print("Saved caption file to: {}".format(downloaded_path))
     else:
         print("Unable to find caption with code: {}".format(lang_code))

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import sys
 from io import BufferedWriter
-from typing import Tuple, Any, Optional, List
+from typing import Any, Optional, List
 
 from pytube import __version__, CaptionQuery, Stream, Playlist
 from pytube import YouTube
@@ -185,6 +185,7 @@ def display_progress_bar(
     sys.stdout.flush()
 
 
+# noinspection PyUnusedLocal
 def on_progress(
     stream: Any, chunk: Any, file_handler: BufferedWriter, bytes_remaining: int
 ) -> None:
@@ -206,7 +207,8 @@ def download_by_itag(youtube: YouTube, itag: int, target: Optional[str] = None) 
         A valid YouTube object.
     :param int itag:
         YouTube format identifier code.
-
+    :param str target:
+        Target directory for download
     """
     # TODO(nficano): allow dash itags to be selected
     stream = youtube.streams.get_by_itag(itag)
@@ -219,7 +221,7 @@ def download_by_itag(youtube: YouTube, itag: int, target: Optional[str] = None) 
     youtube.register_on_progress_callback(on_progress)
 
     try:
-        _download(stream)
+        _download(stream, target=target)
     except KeyboardInterrupt:
         sys.exit()
 
@@ -233,7 +235,8 @@ def download_by_resolution(
         A valid YouTube object.
     :param str resolution:
         YouTube video resolution.
-
+    :param str target:
+        Target directory for download
     """
     # TODO(nficano): allow dash itags to be selected
     stream = youtube.streams.get_by_resolution(resolution)
@@ -250,7 +253,7 @@ def download_by_resolution(
     youtube.register_on_progress_callback(on_progress)
 
     try:
-        _download(stream)
+        _download(stream, target=target)
     except KeyboardInterrupt:
         sys.exit()
 
@@ -285,7 +288,8 @@ def download_caption(
         Language code desired for caption file.
         Prints available codes if the value is None
         or the desired code is not available.
-
+    :param str target:
+        Target directory for download
     """
     if lang_code is None:
         _print_available_captions(youtube.captions)

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -107,7 +107,7 @@ class Playlist:
         return self.video_urls
 
     @deprecated("This function will be removed in the future.")
-    def _path_num_prefix_generator(self, reverse=False):
+    def _path_num_prefix_generator(self, reverse=False):  # pragma: no cover
         """
         This generator function generates number prefixes, for the items
         in the playlist.
@@ -134,7 +134,7 @@ class Playlist:
         prefix_number: bool = True,
         reverse_numbering: bool = False,
         resolution: str = "720p",
-    ) -> None:
+    ) -> None:  # pragma: no cover
         """Download all the videos in the the playlist. Initially, download
         resolution is 720p (or highest available), later more option
         should be added to download resolution of choice

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -5,11 +5,12 @@ import json
 import logging
 import re
 from collections import OrderedDict
-from typing import List, Optional, Iterable
+from typing import List, Optional, Iterable, Dict
 from urllib.parse import parse_qs
 
 from pytube import request, YouTube
 from pytube.helpers import cache, deprecated
+from pytube.mixins import install_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +20,10 @@ class Playlist:
     playlist
     """
 
-    def __init__(self, url: str, suppress_exception: bool = False):
-        self.suppress_exception = suppress_exception
+    def __init__(self, url: str, proxies: Optional[Dict[str, str]] = None):
+        if proxies:
+            install_proxy(proxies)
+
         self.playlist_url: str = url
 
         if "watch?v=" in url:

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -163,27 +163,21 @@ class Playlist:
         prefix_gen = self._path_num_prefix_generator(reverse_numbering)
 
         for link in self.video_urls:
-            try:
-                yt = YouTube(link)
-            except Exception as e:
-                logger.debug(e)
-                if not self.suppress_exception:
-                    raise e
-            else:
-                dl_stream = (
-                    yt.streams.get_by_resolution(resolution=resolution)
-                    or yt.streams.get_lowest_resolution()
-                )
-                assert dl_stream is not None
+            yt = YouTube(link)
+            dl_stream = (
+                yt.streams.get_by_resolution(resolution=resolution)
+                or yt.streams.get_lowest_resolution()
+            )
+            assert dl_stream is not None
 
-                logger.debug("download path: %s", download_path)
-                if prefix_number:
-                    prefix = next(prefix_gen)
-                    logger.debug("file prefix is: %s", prefix)
-                    dl_stream.download(download_path, filename_prefix=prefix)
-                else:
-                    dl_stream.download(download_path)
-                logger.debug("download complete")
+            logger.debug("download path: %s", download_path)
+            if prefix_number:
+                prefix = next(prefix_gen)
+                logger.debug("file prefix is: %s", prefix)
+                dl_stream.download(download_path, filename_prefix=prefix)
+            else:
+                dl_stream.download(download_path)
+            logger.debug("download complete")
 
     @cache
     def title(self) -> Optional[str]:

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -163,10 +163,10 @@ class Playlist:
         prefix_gen = self._path_num_prefix_generator(reverse_numbering)
 
         for link in self.video_urls:
-            yt = YouTube(link)
+            youtube = YouTube(link)
             dl_stream = (
-                yt.streams.get_by_resolution(resolution=resolution)
-                or yt.streams.get_lowest_resolution()
+                youtube.streams.get_by_resolution(resolution=resolution)
+                or youtube.streams.get_lowest_resolution()
             )
             assert dl_stream is not None
 

--- a/pytube/helpers.py
+++ b/pytube/helpers.py
@@ -138,7 +138,7 @@ def deprecated(reason: str) -> Callable:
     return decorator
 
 
-def target_directory(output_path: Optional[str]) -> str:
+def target_directory(output_path: Optional[str] = None) -> str:
     """
     Function for determining target directory of a download.
     Returns an absolute path (if relative one given) or the current

--- a/pytube/helpers.py
+++ b/pytube/helpers.py
@@ -2,6 +2,7 @@
 """Various helper functions implemented by pytube."""
 import functools
 import logging
+import os
 import pprint
 import re
 import warnings
@@ -135,3 +136,13 @@ def deprecated(reason: str) -> Callable:
         return new_func1
 
     return decorator
+
+
+def target_directory(output_path: str) -> str:
+    if output_path:
+        if not os.path.isabs(output_path):
+            output_path = os.path.join(os.getcwd(), output_path)
+    else:
+        output_path = os.getcwd()
+    os.makedirs(output_path, exist_ok=True)
+    return output_path

--- a/pytube/helpers.py
+++ b/pytube/helpers.py
@@ -6,7 +6,7 @@ import os
 import pprint
 import re
 import warnings
-from typing import TypeVar, Callable
+from typing import TypeVar, Callable, Optional
 
 from pytube.exceptions import RegexMatchError
 
@@ -138,7 +138,17 @@ def deprecated(reason: str) -> Callable:
     return decorator
 
 
-def target_directory(output_path: str) -> str:
+def target_directory(output_path: Optional[str]) -> str:
+    """
+    Function for determining target directory of a download.
+    Returns an absolute path (if relative one given) or the current
+    path (if none given). Makes directory if it does not exist.
+
+    :type output_path: str
+        :rtype: str
+    :returns:
+        An absolute directory path as a string.
+    """
     if output_path:
         if not os.path.isabs(output_path):
             output_path = os.path.join(os.getcwd(), output_path)

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -296,7 +296,7 @@ class StreamQuery:
 
         """
         return (
-            self.filter(only_audio=True, codec=codec)
+            self.filter(only_audio=True, audio_codec=codec)
             .order_by("resolution")
             .asc()
             .last()

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -284,7 +284,7 @@ class StreamQuery:
         """
         return self.filter(progressive=True).order_by("resolution").asc().last()
 
-    def get_audio_only(self, codec: str = "mp4") -> Optional[Stream]:
+    def get_audio_only(self, subtype: str = "mp4") -> Optional[Stream]:
         """Get highest bitrate audio stream for given codec (defaults to mp4)
 
         :param str codec:
@@ -296,8 +296,8 @@ class StreamQuery:
 
         """
         return (
-            self.filter(only_audio=True, audio_codec=codec)
-            .order_by("resolution")
+            self.filter(only_audio=True, subtype=subtype)
+            .order_by("abr")
             .asc()
             .last()
         )

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -296,10 +296,7 @@ class StreamQuery:
 
         """
         return (
-            self.filter(only_audio=True, subtype=subtype)
-            .order_by("abr")
-            .asc()
-            .last()
+            self.filter(only_audio=True, subtype=subtype).order_by("abr").asc().last()
         )
 
     def first(self) -> Optional[Stream]:

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -284,7 +284,7 @@ class StreamQuery:
         """
         return self.filter(progressive=True).order_by("resolution").asc().last()
 
-    def get_audio_only(self, codec:str = "mp4") -> Optional[Stream]:
+    def get_audio_only(self, codec: str = "mp4") -> Optional[Stream]:
         """Get highest bitrate audio stream for given codec (defaults to mp4)
 
         :param str codec:
@@ -295,7 +295,12 @@ class StreamQuery:
             not found.
 
         """
-        return self.filter(only_audio=True, codex=codec).order_by("resolution").asc().last()
+        return (
+            self.filter(only_audio=True, codec=codec)
+            .order_by("resolution")
+            .asc()
+            .last()
+        )
 
     def first(self) -> Optional[Stream]:
         """Get the first :class:`Stream <Stream>` in the results.

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -284,6 +284,19 @@ class StreamQuery:
         """
         return self.filter(progressive=True).order_by("resolution").asc().last()
 
+    def get_audio_only(self, codec:str = "mp4") -> Optional[Stream]:
+        """Get highest bitrate audio stream for given codec (defaults to mp4)
+
+        :param str codec:
+            Audio codec, defaults to mp4
+        :rtype: :class:`Stream <Stream>` or None
+        :returns:
+            The :class:`Stream <Stream>` matching the given itag or None if
+            not found.
+
+        """
+        return self.filter(only_audio=True, codex=codec).order_by("resolution").asc().last()
+
     def first(self) -> Optional[Stream]:
         """Get the first :class:`Stream <Stream>` in the results.
 

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -72,9 +72,7 @@ class Stream:
         # Same as above, except for the format profile attributes.
         self.set_attributes_from_dict(self.fmt_profile)
 
-        # The player configuration which contains information like the video
-        # title.
-        # TODO(nficano): this should be moved to the monostate.
+        # The player configuration, contains info like the video title.
         self.player_config_args = player_config_args
 
         # 'video/webm; codecs="vp8, vorbis"' -> 'video/webm', ['vp8', 'vorbis']

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -16,7 +16,7 @@ from typing import Dict, Tuple, Optional, List
 
 from pytube import extract
 from pytube import request
-from pytube.helpers import safe_filename
+from pytube.helpers import safe_filename, target_directory
 from pytube.itags import get_format_profile
 from pytube.monostate import Monostate
 
@@ -227,13 +227,6 @@ class Stream:
         :rtype: str
 
         """
-        if output_path:
-            if not os.path.isabs(output_path):
-                output_path = os.path.join(os.getcwd(), output_path)
-        else:
-            output_path = os.getcwd()
-        os.makedirs(output_path, exist_ok=True)
-
         if filename:
             filename = "{filename}.{s.subtype}".format(
                 filename=safe_filename(filename), s=self
@@ -246,7 +239,7 @@ class Stream:
                 prefix=safe_filename(filename_prefix), filename=filename,
             )
 
-        file_path = os.path.join(output_path, filename)
+        file_path = os.path.join(target_directory(output_path), filename)
 
         if (
             skip_existing

--- a/tests/contrib/test_playlist.py
+++ b/tests/contrib/test_playlist.py
@@ -95,3 +95,12 @@ def test_videos(youtube, request_get, playlist_html):
     playlist._find_load_more_url = MagicMock(return_value=None)
     request_get.assert_called()
     assert len(list(playlist.videos)) == 12
+
+
+@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.contrib.playlist.install_proxy", return_value=None)
+def test_proxy(install_proxy, request_get):
+    url = "https://www.fakeurl.com/playlist?list=whatever"
+    request_get.return_value = ""
+    Playlist(url, proxies={"http": "things"})
+    install_proxy.assert_called_with({"http": "things"})

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -1,7 +1,7 @@
 from unittest import mock
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 
-from pytube import Caption, CaptionQuery
+from pytube import Caption, CaptionQuery, captions
 
 
 def test_float_to_srt_time_format():
@@ -66,6 +66,20 @@ def test_download_with_prefix(srt):
         )
         caption.download("title", filename_prefix="1 ")
         assert open_mock.call_args_list[0][0][0].split("/")[-1] == "1 title (en).srt"
+
+
+@mock.patch("pytube.captions.Caption.generate_srt_captions")
+def test_download_with_output_path(srt):
+    open_mock = mock_open()
+    captions.target_directory = MagicMock(return_value="/target")
+    with patch("builtins.open", open_mock):
+        srt.return_value = ""
+        caption = Caption(
+            {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en"}
+        )
+        file_path = caption.download("title", output_path="blah")
+        assert file_path == "/target/title (en).srt"
+        captions.target_directory.assert_called_with("blah")
 
 
 @mock.patch("pytube.captions.Caption.xml_captions")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_download_caption_with_language_found(youtube):
     caption.download = MagicMock(return_value="file_path")
     youtube.captions = CaptionQuery([caption])
     cli.download_caption(youtube, "en")
-    caption.download.assert_called_with(title="video title")
+    caption.download.assert_called_with(title="video title", output_path=None)
 
 
 @mock.patch("pytube.cli.YouTube")
@@ -181,6 +181,7 @@ def test_download_by_resolution(youtube):
 
 @mock.patch("pytube.cli.Playlist")
 def test_download_with_playlist(playlist):
+    cli.safe_filename = MagicMock(return_value="safe_title")
     parser = argparse.ArgumentParser()
     args = parse_args(parser, ["https://www.youtube.com/playlist?list=PLyn"])
     cli._parse_args = MagicMock(return_value=args)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 
 from pytube import helpers
 from pytube.exceptions import RegexMatchError
-from pytube.helpers import deprecated, cache
+from pytube.helpers import deprecated, cache, target_directory
 
 
 def test_regex_search_no_match():
@@ -52,3 +53,25 @@ def test_cache():
     cached_func("bye")
 
     assert call_count == 2
+
+
+@mock.patch("os.path.isabs", return_value=False)
+@mock.patch("os.getcwd", return_value="/cwd")
+@mock.patch("os.makedirs")
+def test_target_directory_with_relative_path(_, __, makedirs):
+    assert target_directory("test") == "/cwd/test"
+    makedirs.assert_called()
+
+
+@mock.patch("os.path.isabs", return_value=True)
+@mock.patch("os.makedirs")
+def test_target_directory_with_absolute_path(_, makedirs):
+    assert target_directory("/test") == "/test"
+    makedirs.assert_called()
+
+
+@mock.patch("os.getcwd", return_value="/cwd")
+@mock.patch("os.makedirs")
+def test_target_directory_with_no_path(_, makedirs):
+    assert target_directory() == "/cwd"
+    makedirs.assert_called()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -154,3 +154,11 @@ def test_filter_is_dash(cipher_signature):
     streams = cipher_signature.streams.filter(is_dash=False).all()
     itags = [s.itag for s in streams]
     assert itags == [18, 398, 397, 396, 395, 394]
+
+
+def test_get_audio_only(cipher_signature):
+    assert cipher_signature.streams.get_audio_only().itag == 140
+
+
+def test_get_audio_only_with_subtype(cipher_signature):
+    assert cipher_signature.streams.get_audio_only(subtype="webm").itag == 251

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -2,9 +2,10 @@
 import random
 
 from unittest import mock
+from unittest.mock import MagicMock
 
 from pytube import request
-from pytube import Stream
+from pytube import Stream, streams
 
 
 def test_filesize(cipher_signature, mocker):
@@ -43,6 +44,18 @@ def test_download(cipher_signature, mocker):
     with mock.patch("pytube.streams.open", mock.mock_open(), create=True):
         stream = cipher_signature.streams.first()
         stream.download()
+
+
+def test_download_with_prefix(cipher_signature, mocker):
+    mocker.patch.object(request, "headers")
+    request.headers.return_value = {"content-length": "16384"}
+    mocker.patch.object(request, "stream")
+    request.stream.return_value = iter([str(random.getrandbits(8 * 1024))])
+    streams.target_directory = MagicMock(return_value="/target")
+    with mock.patch("pytube.streams.open", mock.mock_open(), create=True):
+        stream = cipher_signature.streams.first()
+        file_path = stream.download(filename_prefix="prefix")
+        assert file_path == "/target/prefixPSY - GANGNAM STYLE(강남스타일) MV.mp4"
 
 
 def test_progressive_streams_return_includes_audio_track(cipher_signature):


### PR DESCRIPTION
* Add `-t` flag to specify target directory for CLI downloads
* CLI playlist downloads use playlist title for target directory if no `-t` flag
* Handling for relative paths and missing directory for target directory
* Optionally skip downloaded videos (defaults to True)
* Add `get_audio_only` query
* Support proxies argument for playlist downloads
* Fix for terminal size on platforms missing `os.get_terminal_size()`