### PR TITLE
Minor refactoring

### DIFF
--- a/pytube/query.py
+++ b/pytube/query.py
@@ -193,9 +193,7 @@ class StreamQuery:
                     sorted(
                         has_attribute,
                         key=lambda s: int(
-                            "".join(
-                                list(filter(str.isdigit, getattr(s, attribute_name)))
-                            )
+                            "".join(filter(str.isdigit, getattr(s, attribute_name)))
                         ),  # type: ignore  # noqa: E501
                     )
                 )

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """This module provides a query interface for media streams and captions."""
-from typing import List, Optional, Dict
+from typing import List, Optional
 
 from pytube import Stream, Caption
 
@@ -186,13 +186,16 @@ class StreamQuery:
         if has_attribute and isinstance(
             getattr(has_attribute[0], attribute_name), str
         ):
-            # Try to return a StreamQuery with the values sorted by their integer representations.
+            # Try to return a StreamQuery sorted by the integer representations
+            # of the values.
             try:
                 return StreamQuery(
                     sorted(
                         has_attribute,
                         key=lambda s: int(
-                            "".join(list(filter(str.isdigit, getattr(s, attribute_name))))
+                            "".join(
+                                list(filter(str.isdigit, getattr(s, attribute_name)))
+                            )
                         ),  # type: ignore  # noqa: E501
                     )
                 )

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -183,9 +183,7 @@ class StreamQuery:
         ]
 
         # Check that the attributes have string values.
-        if has_attribute and isinstance(
-            getattr(has_attribute[0], attribute_name), str
-        ):
+        if has_attribute and isinstance(getattr(has_attribute[0], attribute_name), str):
             # Try to return a StreamQuery sorted by the integer representations
             # of the values.
             try:


### PR DESCRIPTION
Filters can filter iterables, and calling filter produces an iterable, so there's no need to produce intermediate lists between filtering.
Instead of appending all the elements in custom_filter_functions one by one, we can just extend filters by custom_filter_functions.
Instead of building an intermediate dictionary for sorting strings by their numerical representations, we try to sort immediately.