### PR TITLE
Bypass YouTube whole download throttling - resolve #41

### DIFF
--- a/pytube/request.py
+++ b/pytube/request.py
@@ -9,7 +9,9 @@ from urllib.request import urlopen
 def _execute_request(url: str) -> Any:
     if not url.lower().startswith("http"):
         raise ValueError
-    return urlopen(Request(url, headers={"User-Agent": "Mozilla/5.0", "Range": "bytes=0-"}))  # nosec
+    return urlopen(
+        Request(url, headers={"User-Agent": "Mozilla/5.0", "Range": "bytes=0-"})
+    )  # nosec
 
 
 def get(url) -> str:

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -9,7 +9,7 @@ from urllib.request import urlopen
 def _execute_request(url: str) -> Any:
     if not url.lower().startswith("http"):
         raise ValueError
-    return urlopen(Request(url, headers={"User-Agent": "Mozilla/5.0"}))  # nosec
+    return urlopen(Request(url, headers={"User-Agent": "Mozilla/5.0", "Range": "bytes=0-"}))  # nosec
 
 
 def get(url) -> str:


### PR DESCRIPTION
YouTube is throttling downloads without the `Range` header, which is used by browsers when streaming (for example with an implementation of the `<video>` HTML tag ) but not on whole downloads. We can easily bypass this, however, by just adding `Range: bytes=0-` to the request. The result is all the same bytes as before but in a much shorter time.